### PR TITLE
Unlock all evo

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -25,7 +25,20 @@ public class Plugin : BasePlugin
         harmony.PatchAll();
     }
 
-
+    [HarmonyPatch(typeof(AppMainScript), "_FinishedParameterLoad")]
+    public static class UnlockEvo
+    {
+        [HarmonyPrefix]
+        public static void Prefix(AppMainScript __instance)
+        {
+            foreach (ParameterDigimonData param in __instance.m_parameters.digimonData.m_params)
+            {
+                param.m_dlc_flagset = 4011245244;
+                param.m_evo1_flagset = 4011245244;
+                param.m_dlc_no = 0;
+            }
+        }
+    }
 
     [HarmonyPatch(typeof(uRebirthPanel), "enablePanel")]
     public static class UnlockEgg
@@ -33,9 +46,6 @@ public class Plugin : BasePlugin
         [HarmonyPostfix]
         public static void Postfix(uRebirthPanel __instance, bool enable)
         {
-            uint flagSetId = Language.makeHash("flagset_166");
-            StorageData.m_ScenarioProgressData.SetScenarioFlagByFlagSet(flagSetId, true);
-
             __instance.eggMax = 13;
             __instance.m_eggTbl = new int[__instance.eggMax];
 


### PR DESCRIPTION
Remove the flagset and unlock all evolution. Unlocking all evo remove the need for the flagset, which fix issue caused by it.

settings all digimon's m_dlc_flagset & m_evo1_flagset to 4011245244 ( ef16bebc ), which just mean no condition.
set m_dlc_no to 0 is just to unlock boltboutamon.